### PR TITLE
Simplify Singleton and fix invocation target exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language : haskell
 ghc : 7.8.3
+before_install : cabal update
 install : 
   - 'cabal install purescript'
   - "npm install bower gulp -g"

--- a/src/Control/RequestAnimationFrame.purs
+++ b/src/Control/RequestAnimationFrame.purs
@@ -8,36 +8,13 @@ foreign import data RAF :: !
 
 foreign import requestAnimationFrame """
 
-  var rAF = (function(){
-    var singleton;
+  var requestAnimationFrame = (function(){
+    var rAF = typeof requestAnimationFrame === "function" ? requestAnimationFrame :
+              typeof webkitRequestAnimationFrame === "function" ? webkitRequestAnimationFrame :
+              typeof mozRequestAnimationFrame === "function" ? mozRequestAnimationFrame :
+              function(callback) { return setTimeout(callback, 1000 / 60); };
 
-    function init() {
-      var shim = window.requestAnimationFrame       ||
-                 window.webkitRequestAnimationFrame ||
-                 window.mozRequestAnimationFrame    ||
-                 function( callback ){
-                   window.setTimeout(callback, 1000 / 60);
-                 };
-
-      return {
-        requestAnimationFrame : shim
-      };
-    }
-
-    return {
-      getSingleton : function(){
-        if(!singleton) {
-          singleton = init();
-        }
-        return singleton;
-      }
-    }
-  })();
-  
-  function requestAnimationFrame(x) {
-    return function(){ 
-      return rAF.getSingleton().requestAnimationFrame(x); 
-    };
-  };
+    return function(x) { return function(){ return rAF(x); }; };
+  }());
   
 """ :: forall a e. Eff (raf :: RAF | e) a -> Eff (raf :: RAF | e) Unit


### PR DESCRIPTION
Based on code from @michaelficarra here: https://github.com/CapillarySoftware/purescript-requestAnimationFrame/pull/1

I've confirmed that the specs pass locally. Also confirmed working on Firefox and Chrome using my own Canvas and requestAnimationFrame project. However, on Chrome there is a warning in the JavaScript console:
'webkitRequestAnimationFrame' is vendor-specific. Please use the standard 'requestAnimationFrame' instead.

Unfortunately, I couldn't figure out a way to write a corresponding test case for this to ensure that requestAnimationFrame is called with the window as its context. Would love to if it is possible and if anybody has any pointers.
